### PR TITLE
Include board.h from the top level directory to avoid zephyr conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-zephyr_include_directories(boards)
 zephyr_include_directories(mac)
 zephyr_include_directories(radio)
 zephyr_include_directories(./)

--- a/boards/mcu/utilities.c
+++ b/boards/mcu/utilities.c
@@ -22,7 +22,7 @@
  */
 #include <stdlib.h>
 #include <stdio.h>
-#include "utilities.h"
+#include "boards/utilities.h"
 
 /*!
  * Redefinition of rand() and srand() standard C functions.

--- a/radio/sx1276/sx1276.c
+++ b/radio/sx1276/sx1276.c
@@ -24,12 +24,12 @@
  */
 #include <math.h>
 #include <string.h>
-#include "utilities.h"
+#include "boards/utilities.h"
 #include "system/timer.h"
 #include "radio.h"
 #include "system/delay.h"
 #include "sx1276.h"
-#include "sx1276-board.h"
+#include "boards/sx1276-board.h"
 
 /*
  * Local types definition

--- a/system/delay.c
+++ b/system/delay.c
@@ -20,7 +20,7 @@
  *
  * \author    Gregory Cristian ( Semtech )
  */
-#include "delay-board.h"
+#include "boards/delay-board.h"
 #include "delay.h"
 
 void Delay( float s )

--- a/system/gpio.h
+++ b/system/gpio.h
@@ -28,8 +28,8 @@
 #define __GPIO_H__
 
 #include <stdint.h>
-#include "pinName-board.h"
-#include "pinName-ioe.h"
+#include "boards/pinName-board.h"
+#include "boards/pinName-ioe.h"
 
 /*!
  * Board GPIO pin names

--- a/system/timer.c
+++ b/system/timer.c
@@ -20,9 +20,9 @@
  *
  * \author    Gregory Cristian ( Semtech )
  */
-#include "utilities.h"
-#include "board.h"
-#include "rtc-board.h"
+#include "boards/utilities.h"
+#include "boards/board.h"
+#include "boards/rtc-board.h"
 #include "timer.h"
 
 /*!


### PR DESCRIPTION
Since board.h header in zephyr conflicts with loramac-node, move the
include one level up here so that it will become "boards/board.h".

Signed-off-by: Manivannan Sadhasivam <mani@kernel.org>