### PR TITLE
Add LoRaWAN support for Zephyr

### DIFF
--- a/src/boards/utilities.h
+++ b/src/boards/utilities.h
@@ -48,7 +48,9 @@ extern "C"
  * \param [IN] b 2nd value
  * \retval minValue Minimum value
  */
+#ifndef MIN
 #define MIN( a, b ) ( ( ( a ) < ( b ) ) ? ( a ) : ( b ) )
+#endif
 
 /*!
  * \brief Returns the maximum value between a and b
@@ -57,7 +59,9 @@ extern "C"
  * \param [IN] b 2nd value
  * \retval maxValue Maximum value
  */
+#ifndef MAX
 #define MAX( a, b ) ( ( ( a ) > ( b ) ) ? ( a ) : ( b ) )
+#endif
 
 /*!
  * \brief Returns 2 raised to the power of n

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -16,10 +16,15 @@ zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/mac/LoRaMacCrypto
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/mac/LoRaMacParser.c)
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/mac/LoRaMacSerializer.c)
 
+zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/peripherals/soft-se/aes.c)
+zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/peripherals/soft-se/cmac.c)
+zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/peripherals/soft-se/soft-se.c)
+
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_SX1276 ../src/radio/sx1276/sx1276.c)
 
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/system/timer.c)
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/system/delay.c)
+zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/system/systime.c)
 
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/boards/mcu/utilities.c)
 


### PR DESCRIPTION
This PR rebases onto loramac-node master and also adds LoRaWAN support for Zephyr by enabling necessary drivers.

Signed-off-by: Manivannan Sadhasivam <mani@kernel.org>