### PR TITLE
Support SX126x RF switch controlled by MCU

### DIFF
--- a/src/boards/NucleoL073/sx1261mbxbas-board.c
+++ b/src/boards/NucleoL073/sx1261mbxbas-board.c
@@ -101,6 +101,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL073/sx1261mbxbas-board.c
+++ b/src/boards/NucleoL073/sx1261mbxbas-board.c
@@ -28,6 +28,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -78,6 +99,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -274,12 +323,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/NucleoL073/sx1262mbxcas-board.c
+++ b/src/boards/NucleoL073/sx1262mbxcas-board.c
@@ -101,6 +101,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL073/sx1262mbxcas-board.c
+++ b/src/boards/NucleoL073/sx1262mbxcas-board.c
@@ -28,6 +28,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -78,6 +99,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -274,12 +323,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/NucleoL073/sx1262mbxdas-board.c
+++ b/src/boards/NucleoL073/sx1262mbxdas-board.c
@@ -108,6 +108,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL073/sx1262mbxdas-board.c
+++ b/src/boards/NucleoL073/sx1262mbxdas-board.c
@@ -31,6 +31,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -85,6 +106,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -281,12 +330,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/NucleoL152/sx1261mbxbas-board.c
+++ b/src/boards/NucleoL152/sx1261mbxbas-board.c
@@ -101,6 +101,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL152/sx1261mbxbas-board.c
+++ b/src/boards/NucleoL152/sx1261mbxbas-board.c
@@ -28,6 +28,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -78,6 +99,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -274,12 +323,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/NucleoL152/sx1262mbxcas-board.c
+++ b/src/boards/NucleoL152/sx1262mbxcas-board.c
@@ -101,6 +101,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL152/sx1262mbxcas-board.c
+++ b/src/boards/NucleoL152/sx1262mbxcas-board.c
@@ -28,6 +28,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -78,6 +99,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -274,12 +323,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/NucleoL152/sx1262mbxdas-board.c
+++ b/src/boards/NucleoL152/sx1262mbxdas-board.c
@@ -108,6 +108,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL152/sx1262mbxdas-board.c
+++ b/src/boards/NucleoL152/sx1262mbxdas-board.c
@@ -31,6 +31,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -85,6 +106,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -281,12 +330,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/NucleoL476/sx1261mbxbas-board.c
+++ b/src/boards/NucleoL476/sx1261mbxbas-board.c
@@ -101,6 +101,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL476/sx1261mbxbas-board.c
+++ b/src/boards/NucleoL476/sx1261mbxbas-board.c
@@ -28,6 +28,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -78,6 +99,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -274,12 +323,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/NucleoL476/sx1262mbxcas-board.c
+++ b/src/boards/NucleoL476/sx1262mbxcas-board.c
@@ -101,6 +101,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL476/sx1262mbxcas-board.c
+++ b/src/boards/NucleoL476/sx1262mbxcas-board.c
@@ -28,6 +28,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -78,6 +99,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -274,12 +323,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/NucleoL476/sx1262mbxdas-board.c
+++ b/src/boards/NucleoL476/sx1262mbxdas-board.c
@@ -108,6 +108,11 @@ uint32_t SX126xGetBoardTcxoWakeupTime( void )
     return BOARD_TCXO_WAKEUP_TIME;
 }
 
+void SX126xIoRfSwitchInit( void )
+{
+    SX126xSetDio2AsRfSwitchCtrl( true );
+}
+
 RadioOperatingModes_t SX126xGetOperatingMode( void )
 {
     return OperatingMode;

--- a/src/boards/NucleoL476/sx1262mbxdas-board.c
+++ b/src/boards/NucleoL476/sx1262mbxdas-board.c
@@ -31,6 +31,27 @@
 #include "radio.h"
 #include "sx126x-board.h"
 
+#if defined( USE_RADIO_DEBUG )
+/*!
+ * \brief Writes new Tx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+static void SX126xDbgPinTxWrite( uint8_t state );
+
+/*!
+ * \brief Writes new Rx debug pin state
+ *
+ * \param [IN] state Debug pin state
+ */
+void SX126xDbgPinRxWrite( uint8_t state );
+#endif
+
+/*!
+ * \brief Holds the internal operating mode of the radio
+ */
+static RadioOperatingModes_t OperatingMode;
+
 /*!
  * Antenna switch GPIO pins objects
  */
@@ -85,6 +106,34 @@ void SX126xIoTcxoInit( void )
 uint32_t SX126xGetBoardTcxoWakeupTime( void )
 {
     return BOARD_TCXO_WAKEUP_TIME;
+}
+
+RadioOperatingModes_t SX126xGetOperatingMode( void )
+{
+    return OperatingMode;
+}
+
+void SX126xSetOperatingMode( RadioOperatingModes_t mode )
+{
+    OperatingMode = mode;
+#if defined( USE_RADIO_DEBUG )
+    switch( mode )
+    {
+        case MODE_TX:
+            SX126xDbgPinTxWrite( 1 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+        case MODE_RX:
+        case MODE_RX_DC:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 1 );
+            break;
+        default:
+            SX126xDbgPinTxWrite( 0 );
+            SX126xDbgPinRxWrite( 0 );
+            break;
+    }
+#endif
 }
 
 void SX126xReset( void )
@@ -281,12 +330,12 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 }
 
 #if defined( USE_RADIO_DEBUG )
-void SX126xDbgPinTxWrite( uint8_t state )
+static void SX126xDbgPinTxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinTx, state );
 }
 
-void SX126xDbgPinRxWrite( uint8_t state )
+static void SX126xDbgPinRxWrite( uint8_t state )
 {
     GpioWrite( &DbgPinRx, state );
 }

--- a/src/boards/sx126x-board.h
+++ b/src/boards/sx126x-board.h
@@ -155,18 +155,21 @@ bool SX126xCheckRfFrequency( uint32_t frequency );
 uint32_t SX126xGetBoardTcxoWakeupTime( void );
 
 /*!
- * \brief Writes new Tx debug pin state
+ * \brief Gets the current Radio OperationMode variable
  *
- * \param [IN] state Debug pin state
+ * \retval      RadioOperatingModes_t last operating mode
  */
-void SX126xDbgPinTxWrite( uint8_t state );
+RadioOperatingModes_t SX126xGetOperatingMode( void );
 
 /*!
- * \brief Writes new Rx debug pin state
+ * \brief Sets/Updates the current Radio OperationMode variable.
  *
- * \param [IN] state Debug pin state
+ * \remark WARNING: This function is only required to reflect the current radio
+ *                  operating mode when processing interrupts.
+ *
+ * \param [in] mode           New operating mode
  */
-void SX126xDbgPinRxWrite( uint8_t state );
+void SX126xSetOperatingMode( RadioOperatingModes_t mode );
 
 /*!
  * Radio hardware and global parameters

--- a/src/boards/sx126x-board.h
+++ b/src/boards/sx126x-board.h
@@ -57,6 +57,11 @@ void SX126xIoDeInit( void );
 void SX126xIoTcxoInit( void );
 
 /*!
+ * \brief Initializes RF switch control pins.
+ */
+void SX126xIoRfSwitchInit( void );
+
+/*!
  * \brief Initializes the radio debug pins.
  */
 void SX126xIoDbgInit( void );

--- a/src/radio/sx126x/sx126x.c
+++ b/src/radio/sx126x/sx126x.c
@@ -93,7 +93,9 @@ void SX126xInit( DioIrqHandler dioIrq )
     // Initialize TCXO control
     SX126xIoTcxoInit( );
 
-    SX126xSetDio2AsRfSwitchCtrl( true );
+    // Initialize RF switch control
+    SX126xIoRfSwitchInit( );
+
     SX126xSetOperatingMode( MODE_STDBY_RC );
 }
 

--- a/src/radio/sx126x/sx126x.c
+++ b/src/radio/sx126x/sx126x.c
@@ -38,11 +38,6 @@ typedef struct
 }RadioRegisters_t;
 
 /*!
- * \brief Holds the internal operating mode of the radio
- */
-static RadioOperatingModes_t OperatingMode;
-
-/*!
  * \brief Stores the current packet type set in the radio
  */
 static RadioPacketTypes_t PacketType;
@@ -100,34 +95,6 @@ void SX126xInit( DioIrqHandler dioIrq )
 
     SX126xSetDio2AsRfSwitchCtrl( true );
     SX126xSetOperatingMode( MODE_STDBY_RC );
-}
-
-RadioOperatingModes_t SX126xGetOperatingMode( void )
-{
-    return OperatingMode;
-}
-
-void SX126xSetOperatingMode( RadioOperatingModes_t mode )
-{
-    OperatingMode = mode;
-#if defined( USE_RADIO_DEBUG )
-    switch( mode )
-    {
-        case MODE_TX:
-            SX126xDbgPinTxWrite( 1 );
-            SX126xDbgPinRxWrite( 0 );
-            break;
-        case MODE_RX:
-        case MODE_RX_DC:
-            SX126xDbgPinTxWrite( 0 );
-            SX126xDbgPinRxWrite( 1 );
-            break;
-        default:
-            SX126xDbgPinTxWrite( 0 );
-            SX126xDbgPinRxWrite( 0 );
-            break;
-    }
-#endif
 }
 
 void SX126xCheckDeviceReady( void )

--- a/src/radio/sx126x/sx126x.c
+++ b/src/radio/sx126x/sx126x.c
@@ -331,11 +331,13 @@ void SX126xSetCad( void )
 
 void SX126xSetTxContinuousWave( void )
 {
+    SX126xSetOperatingMode( MODE_TX );
     SX126xWriteCommand( RADIO_SET_TXCONTINUOUSWAVE, 0, 0 );
 }
 
 void SX126xSetTxInfinitePreamble( void )
 {
+    SX126xSetOperatingMode( MODE_TX );
     SX126xWriteCommand( RADIO_SET_TXCONTINUOUSPREAMBLE, 0, 0 );
 }
 

--- a/src/radio/sx126x/sx126x.h
+++ b/src/radio/sx126x/sx126x.h
@@ -720,23 +720,6 @@ typedef struct
 void SX126xInit( DioIrqHandler dioIrq );
 
 /*!
- * \brief Gets the current Radio OperationMode variable
- *
- * \retval      RadioOperatingModes_t last operating mode
- */
-RadioOperatingModes_t SX126xGetOperatingMode( void );
-
-/*!
- * \brief Sets/Updates the current Radio OperationMode variable.
- *
- * \remark WARNING: This function is only required to reflect the current radio
- *                  operating mode when processing interrupts.
- *
- * \param [in] mode           New operating mode
- */
-void SX126xSetOperatingMode( RadioOperatingModes_t mode );
-
-/*!
  * \brief Wakeup the radio if it is in Sleep mode and check that Busy is low
  */
 void SX126xCheckDeviceReady( void );


### PR DESCRIPTION
This PR contains a series of changes that add support for SX126x radio state tracking from Zephyr. These changes are needed to support RF switches that are wired to MCU GPIOs instead of directly to the radio.

~**NOTE**: Depends on #4 which adds build configs for SX126X.~
~**NOTE**: There isn't a PR for the Zephyr side yet since the base SX126x driver hasn't been merged. See https://github.com/andysan/zephyr/tree/sx126x-rf-switch for my development branch.~
**NOTE**: This is a dependency for https://github.com/zephyrproject-rtos/zephyr/pull/26611