### PR TITLE
radio: sx1272: Support Zephyr SX1272 driver

### DIFF
--- a/src/radio/sx1272/sx1272.c
+++ b/src/radio/sx1272/sx1272.c
@@ -1104,6 +1104,7 @@ uint8_t SX1272Read( uint16_t addr )
     return data;
 }
 
+#ifndef __ZEPHYR__
 void SX1272WriteBuffer( uint16_t addr, uint8_t *buffer, uint8_t size )
 {
     uint8_t i;
@@ -1138,6 +1139,7 @@ void SX1272ReadBuffer( uint16_t addr, uint8_t *buffer, uint8_t size )
     //NSS = 1;
     GpioWrite( &SX1272.Spi.Nss, 1 );
 }
+#endif
 
 void SX1272WriteFifo( uint8_t *buffer, uint8_t size )
 {

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -20,6 +20,7 @@ zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/peripherals/soft-
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/peripherals/soft-se/cmac.c)
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_LORAMAC ../src/peripherals/soft-se/soft-se.c)
 
+zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_SX1272 ../src/radio/sx1272/sx1272.c)
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_SX1276 ../src/radio/sx1276/sx1276.c)
 
 zephyr_library_sources_ifdef(CONFIG_HAS_SEMTECH_SX126X ../src/radio/sx126x/sx126x.c)


### PR DESCRIPTION
Add sx1272.c source if the board has a SX1272 configured.

Allow override of SX1272ReadBuffer and SX1272WriteBuffer.

Signed-off-by: Alexander Mihajlovic <a@abxy.se>