### PR TITLE
Fix infinite loop on CRC error

### DIFF
--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -1123,6 +1123,8 @@ void RadioIrqProcess( void )
 
         if( ( irqRegs & IRQ_RX_DONE ) == IRQ_RX_DONE )
         {
+            TimerStop( &RxTimeoutTimer );
+
             if( ( irqRegs & IRQ_CRC_ERROR ) == IRQ_CRC_ERROR )
             {
                 if( RxContinuous == false )
@@ -1139,7 +1141,6 @@ void RadioIrqProcess( void )
             {
                 uint8_t size;
 
-                TimerStop( &RxTimeoutTimer );
                 if( RxContinuous == false )
                 {
                     //!< Update operating mode state to a value lower than \ref MODE_STDBY_XOSC

--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -1123,39 +1123,41 @@ void RadioIrqProcess( void )
 
         if( ( irqRegs & IRQ_RX_DONE ) == IRQ_RX_DONE )
         {
-            uint8_t size;
-
-            TimerStop( &RxTimeoutTimer );
-            if( RxContinuous == false )
+            if( ( irqRegs & IRQ_CRC_ERROR ) == IRQ_CRC_ERROR )
             {
-                //!< Update operating mode state to a value lower than \ref MODE_STDBY_XOSC
-                SX126xSetOperatingMode( MODE_STDBY_RC );
-
-                // WORKAROUND - Implicit Header Mode Timeout Behavior, see DS_SX1261-2_V1.2 datasheet chapter 15.3
-                // RegRtcControl = @address 0x0902
-                SX126xWriteRegister( 0x0902, 0x00 );
-                // RegEventMask = @address 0x0944
-                SX126xWriteRegister( 0x0944, SX126xReadRegister( 0x0944 ) | ( 1 << 1 ) );
-                // WORKAROUND END
+                if( RxContinuous == false )
+                {
+                    //!< Update operating mode state to a value lower than \ref MODE_STDBY_XOSC
+                    SX126xSetOperatingMode( MODE_STDBY_RC );
+                }
+                if( ( RadioEvents != NULL ) && ( RadioEvents->RxError ) )
+                {
+                    RadioEvents->RxError( );
+                }
             }
-            SX126xGetPayload( RadioRxPayload, &size , 255 );
-            SX126xGetPacketStatus( &RadioPktStatus );
-            if( ( RadioEvents != NULL ) && ( RadioEvents->RxDone != NULL ) )
+            else
             {
-                RadioEvents->RxDone( RadioRxPayload, size, RadioPktStatus.Params.LoRa.RssiPkt, RadioPktStatus.Params.LoRa.SnrPkt );
-            }
-        }
+                uint8_t size;
 
-        if( ( irqRegs & IRQ_CRC_ERROR ) == IRQ_CRC_ERROR )
-        {
-            if( RxContinuous == false )
-            {
-                //!< Update operating mode state to a value lower than \ref MODE_STDBY_XOSC
-                SX126xSetOperatingMode( MODE_STDBY_RC );
-            }
-            if( ( RadioEvents != NULL ) && ( RadioEvents->RxError ) )
-            {
-                RadioEvents->RxError( );
+                TimerStop( &RxTimeoutTimer );
+                if( RxContinuous == false )
+                {
+                    //!< Update operating mode state to a value lower than \ref MODE_STDBY_XOSC
+                    SX126xSetOperatingMode( MODE_STDBY_RC );
+
+                    // WORKAROUND - Implicit Header Mode Timeout Behavior, see DS_SX1261-2_V1.2 datasheet chapter 15.3
+                    // RegRtcControl = @address 0x0902
+                    SX126xWriteRegister( 0x0902, 0x00 );
+                    // RegEventMask = @address 0x0944
+                    SX126xWriteRegister( 0x0944, SX126xReadRegister( 0x0944 ) | ( 1 << 1 ) );
+                    // WORKAROUND END
+                }
+                SX126xGetPayload( RadioRxPayload, &size , 255 );
+                SX126xGetPacketStatus( &RadioPktStatus );
+                if( ( RadioEvents != NULL ) && ( RadioEvents->RxDone != NULL ) )
+                {
+                    RadioEvents->RxDone( RadioRxPayload, size, RadioPktStatus.Params.LoRa.RssiPkt, RadioPktStatus.Params.LoRa.SnrPkt );
+                }
             }
         }
 


### PR DESCRIPTION
This PR cherry-picks two commits from the upstream repository that resolve https://github.com/zephyrproject-rtos/zephyr/issues/36074.

The core of these commits is that only one of the CRC Error and RX done handlers are run, instead of the RX done running and then the CRC Error running.

This is done as a dedicated PR (instead of waiting for #9) to allow these fixes to be used directly by Zephyr v2.5 and Zephyr v2.6 without requiring additional changes in the Zephyr drivers.