### PR TITLE
Add Zephyr-related changes on top of LoRaMac-node v4.5.2

### DIFF
--- a/src/radio/sx1272/sx1272.c
+++ b/src/radio/sx1272/sx1272.c
@@ -1148,6 +1148,7 @@ uint8_t SX1272Read( uint32_t addr )
     return data;
 }
 
+#ifndef __ZEPHYR__
 void SX1272WriteBuffer( uint32_t addr, uint8_t *buffer, uint8_t size )
 {
     uint8_t i;
@@ -1182,6 +1183,7 @@ void SX1272ReadBuffer( uint32_t addr, uint8_t *buffer, uint8_t size )
     //NSS = 1;
     GpioWrite( &SX1272.Spi.Nss, 1 );
 }
+#endif
 
 static void SX1272WriteFifo( uint8_t *buffer, uint8_t size )
 {

--- a/src/radio/sx1276/sx1276.c
+++ b/src/radio/sx1276/sx1276.c
@@ -1288,6 +1288,7 @@ uint8_t SX1276Read( uint32_t addr )
     return data;
 }
 
+#ifndef __ZEPHYR__
 void SX1276WriteBuffer( uint32_t addr, uint8_t *buffer, uint8_t size )
 {
     uint8_t i;
@@ -1322,6 +1323,7 @@ void SX1276ReadBuffer( uint32_t addr, uint8_t *buffer, uint8_t size )
     //NSS = 1;
     GpioWrite( &SX1276.Spi.Nss, 1 );
 }
+#endif
 
 static void SX1276WriteFifo( uint8_t *buffer, uint8_t size )
 {

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,5 @@
+name: loramac-node
+
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
This is the continuation of #9 in a new branch.
https://github.com/zephyrproject-rtos/zephyr/pull/35892 is also reworked to match the new structure.
