### PR TITLE
utilities: fix few shadowed variables

### DIFF
--- a/src/boards/mcu/utilities.c
+++ b/src/boards/mcu/utilities.c
@@ -107,7 +107,7 @@ uint32_t Crc32( uint8_t *buffer, uint16_t length )
     for( uint16_t i = 0; i < length; ++i )
     {
         crc ^= ( uint32_t )buffer[i];
-        for( uint16_t i = 0; i < 8; i++ )
+        for( uint16_t j = 0; j < 8; j++ )
         {
             crc = ( crc >> 1 ) ^ ( reversedPolynom & ~( ( crc & 0x01 ) - 1 ) );
         }
@@ -137,7 +137,7 @@ uint32_t Crc32Update( uint32_t crcInit, uint8_t *buffer, uint16_t length )
     for( uint16_t i = 0; i < length; ++i )
     {
         crc ^= ( uint32_t )buffer[i];
-        for( uint16_t i = 0; i < 8; i++ )
+        for( uint16_t j = 0; j < 8; j++ )
         {
             crc = ( crc >> 1 ) ^ ( reversedPolynom & ~( ( crc & 0x01 ) - 1 ) );
         }


### PR DESCRIPTION
Fix a couple of:

settings_mgmt.c:414:30: warning: declaration of ‘ok’ shadows a previous local [-Wshadow]
  414 |                         bool ok;
      |                              ^~