### PR TITLE
utilities: fix one more shadowed variable

### DIFF
--- a/src/boards/utilities.h
+++ b/src/boards/utilities.h
@@ -182,6 +182,8 @@ uint32_t Crc32Finalize( uint32_t crc );
  */
 #define CRITICAL_SECTION_BEGIN( ) uint32_t mask; BoardCriticalSectionBegin( &mask )
 
+#define CRITICAL_SECTION_BEGIN_REPEAT( ) BoardCriticalSectionBegin( &mask )
+
 /*!
  * Ends critical section
  */

--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -1261,7 +1261,7 @@ void RadioIrqProcess( void )
         SX126xClearIrqStatus( irqRegs );
 
         // Check if DIO1 pin is High. If it is the case revert IrqFired to true
-        CRITICAL_SECTION_BEGIN( );
+        CRITICAL_SECTION_BEGIN_REPEAT( );
         if( SX126xGetDio1PinState( ) == 1 )
         {
             IrqFired = true;


### PR DESCRIPTION
Looks like I missed one in the last patch somehow.

---

Fix one more shadowed variable in the radio driver.

utilities.h:183:44: error: declaration of 'mask' shadows a previous local [-Werror=shadow]
  183 | #define CRITICAL_SECTION_BEGIN( ) uint32_t mask; BoardCritica...
      |                                            ^~~~